### PR TITLE
Fix attribute resolution

### DIFF
--- a/src/RenderPreloadLinks.php
+++ b/src/RenderPreloadLinks.php
@@ -78,11 +78,11 @@ class RenderPreloadLinks
 
     protected function getAsAttribute(string $path): ?string
     {
-        if (Str::endsWith($path, '.js')) {
+        if (Str::contains($path, '.js')) {
             return 'script';
         }
 
-        if (Str::endsWith($path, '.css')) {
+        if (Str::contains($path, '.css')) {
             return 'style';
         }
 


### PR DESCRIPTION
Hi @sebastiandedeyne 

A mix manifest file might contain versioned files, such as

"/prefetch-page-0.js?id=a3b065490ac20417af92"